### PR TITLE
Added requirements.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+lib/
+include/
+pip-selfcheck.json
+.Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+beautifulsoup4==4.6.0
+certifi==2017.7.27.1
+chardet==3.0.4
+idna==2.6
+MechanicalSoup==0.7.0
+requests==2.18.4
+six==1.10.0
+urllib3==1.22


### PR DESCRIPTION
Cloned to a virtual environment for a "clean" Python install (that's what all the stuff is in the .gitignore, you can delete it though, if you want to). Ran `pip install mechanicalsoup` to install that module and its dependencies. Then I ran `pip freeze > requirements.txt` so that there is a requirements file for all required modules.

The requirements file will allow new systems to install all required dependencies in one command (`pip install -r requirements.txt`)

Let me know any changes you'd like for me to make.